### PR TITLE
Clean up empty jar files in cache folder in case of download error

### DIFF
--- a/utils/download/download.go
+++ b/utils/download/download.go
@@ -53,9 +53,12 @@ func ToFile(url string, dir string, allowCached bool) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer file.Close()
-	if err := download(url, file); err != nil {
-		return "", err
+	downloadErr := download(url, file)
+	file.Close()
+	if downloadErr != nil {
+		// remove empty file
+		os.Remove(filename)
+		return "", downloadErr
 	}
 	return filename, nil
 }


### PR DESCRIPTION
When a jar file is not available on the network then OWL creates an empty jar file in the cache folder. Next time when the user run OWL with the same JNLP file he or she will get an error:
![image](https://user-images.githubusercontent.com/34669449/68065963-c7a2ed80-fd52-11e9-9316-41751912251c.png)
The error occurs because the empty jar file in the cache folder is newer than the corresponding jar file on the network.

This fix is to clean up empty jar files in case of download error.