### PR TITLE
Fix for uninstall command in Windows registry

### DIFF
--- a/launcher/jnlp/launcher.go
+++ b/launcher/jnlp/launcher.go
@@ -782,7 +782,7 @@ func (launcher *Launcher) getOriginalFilePath() string {
 
 func (launcher *Launcher) installApp() error {
 	info := launcher.jnlp.Information
-	uninstallString := os.Args[0] + " -uninstall -gui " + launcher.getOriginalFilePath()
+	uninstallString := os.Args[0] + " -uninstall -gui \"" + launcher.getOriginalFilePath() + "\""
 	url := ""
 	if info.Homepage != nil {
 		url = info.Homepage.Href


### PR DESCRIPTION
I got an error when I tried to remove a JNLP app in Window Control Panel: 
![image](https://user-images.githubusercontent.com/34669449/73650915-1be8a100-46a5-11ea-8ff3-540bc938dc74.png). That happened because the path to `original.jnlp` file wasn't enclosed in double quotes. It looks like the issue occurs since the path to the Open Web Launch cache folder had been changed(The path contains spaces). 