### PR TITLE
Add a Window Registry key to control if HTTP(S)_PROXY environment variables should be used

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -41,8 +41,6 @@ func Run(productName, productTitle, productVersion string) {
 			}
 		}
 	}
-	os.Setenv("HTTP_PROXY", "")
-	os.Setenv("HTTPS_PROXY", "")
 	userConfigDir, err := os.UserConfigDir()
 
 	userConfigDir = filepath.Join(userConfigDir, "Rocket Software")
@@ -73,6 +71,15 @@ func Run(productName, productTitle, productVersion string) {
 	log.SetOutput(logFile)
 	log.Printf("starting %s %s with arguments %v\n", productTitle, productVersion, os.Args)
 	log.Printf("current platform is OS=%q Architecture=%q\n", runtime.GOOS, runtime.GOARCH)
+	log.Printf("proxy settings are HTTP_PROXY=%s HTTPS_PROXY=%s NO_PROXY=%s UseHttpProxyEnvironmentVariable is %v\n",
+		os.Getenv("HTTP_PROXY"), os.Getenv("HTTPS_PROXY"), os.Getenv("NO_PROXY"),
+		settings.UseHttpProxyEnvironmentVariable(),
+	)
+	if !settings.UseHttpProxyEnvironmentVariable() {
+		os.Setenv("HTTP_PROXY", "")
+		os.Setenv("HTTPS_PROXY", "")
+		os.Setenv("NO_PROXY", "")
+	}
 	flag.BoolVar(&showConsole, "showconsole", false, "show Java console")
 	flag.BoolVar(&showConsole, "showConsole", false, "show Java console")
 	flag.StringVar(&javaDir, "javadir", "", "Java folder that should be used for starting a Java Web Start application")

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -41,6 +41,8 @@ func Run(productName, productTitle, productVersion string) {
 			}
 		}
 	}
+	os.Setenv("HTTP_PROXY", "")
+	os.Setenv("HTTPS_PROXY", "")
 	userConfigDir, err := os.UserConfigDir()
 
 	userConfigDir = filepath.Join(userConfigDir, "Rocket Software")
@@ -51,7 +53,7 @@ func Run(productName, productTitle, productVersion string) {
 	if err := utils.CreateProductWorkDir(userConfigDir); err != nil {
 		log.Fatal(err)
 	}
-	
+
 	productWorkDir := filepath.Join(userConfigDir, "cache")
 	if err := utils.CreateProductWorkDir(productWorkDir); err != nil {
 		log.Fatal(err)

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -17,13 +17,14 @@ import (
 )
 
 var (
-	javaExecutable                string
-	javaSource                    string
-	jarSignerExecutable           string
-	disableVerification           bool
-	disableVerificationSameOrigin bool
-	addAppToControlPanel          bool
-	currentJavaVersion            *JavaVersion
+	javaExecutable                  string
+	javaSource                      string
+	jarSignerExecutable             string
+	disableVerification             bool
+	disableVerificationSameOrigin   bool
+	addAppToControlPanel            bool
+	currentJavaVersion              *JavaVersion
+	useHttpProxyEnvironmentVariable bool
 )
 
 func EnsureJavaExecutableAvailability() error {
@@ -239,10 +240,15 @@ func DisableVerificationSameOrigin() {
 	disableVerificationSameOrigin = true
 }
 
+func UseHttpProxyEnvironmentVariable() bool {
+	return useHttpProxyEnvironmentVariable
+}
+
 func init() {
 	javaExecutable = getJavaExecutable()
 	jarSignerExecutable = getJARSignerExecutable()
 	disableVerification = getDisableVerificationSetting()
 	disableVerificationSameOrigin = getDisableVerificationSameOriginSetting()
 	addAppToControlPanel = getAddAppToControlPanelSetting()
+	useHttpProxyEnvironmentVariable = getUseHttpProxyEnvironmentVariableSetting()
 }

--- a/settings/settings_darwin.go
+++ b/settings/settings_darwin.go
@@ -88,3 +88,7 @@ func decodeSettings() (*Settings, error) {
 	}
 	return &settings, nil
 }
+
+func getUseHttpProxyEnvironmentVariableSetting() bool {
+	return true
+}

--- a/settings/settings_linux.go
+++ b/settings/settings_linux.go
@@ -33,3 +33,7 @@ func getDisableVerificationSameOriginSetting() bool {
 func getAddAppToControlPanelSetting() bool {
 	return false
 }
+
+func getUseHttpProxyEnvironmentVariableSetting() bool {
+	return true
+}

--- a/settings/settings_windows.go
+++ b/settings/settings_windows.go
@@ -55,6 +55,10 @@ func getAddAppToControlPanelSettingFromRootKey(rootKey registry.Key) (uint64, er
 	return getUInt64ValueFromRootKey(rootKey, "AddToControlPanel")
 }
 
+func getUseHttpProxyEnvironmentVariableSettingFromRootKey(rootKey registry.Key) (uint64, error) {
+	return getUInt64ValueFromRootKey(rootKey, "UseHttpProxyEnvironmentVariable")
+}
+
 func getDisableVerificationSettingFromRootKey(rootKey registry.Key) (uint64, error) {
 	return getUInt64ValueFromRootKey(rootKey, "DisableVerification")
 }
@@ -238,4 +242,15 @@ func getAddAppToControlPanelSetting() bool {
 		return false
 	}
 	return addAppToControlPanel == 1
+}
+
+func getUseHttpProxyEnvironmentVariableSetting() bool {
+	useHttpProxyEnvVar, err := getUseHttpProxyEnvironmentVariableSettingFromRootKey(registry.CURRENT_USER)
+	if err != nil {
+		useHttpProxyEnvVar, err = getUseHttpProxyEnvironmentVariableSettingFromRootKey(registry.LOCAL_MACHINE)
+	}
+	if err != nil {
+		return true
+	}
+	return useHttpProxyEnvVar == 1
 }


### PR DESCRIPTION
By default, golang HTTP client uses `HTTP_PROXY` and `HTTPS_PROXY` environment variables as proxy settings. When on the user's system these variables occasionally set to wrong values(e.g. there is another software that controls the variables), OWL doesn't work properly. The purpose of this PR is to provide an option in Window Registry to control these environment variables:
New key: `UseHttpProxyEnvironmentVariable` (DWORD)
