### PR TITLE
add Wait function to Launcher

### DIFF
--- a/launcher/jnlp/launcher.go
+++ b/launcher/jnlp/launcher.go
@@ -129,6 +129,15 @@ func (launcher *Launcher) Terminate() {
 	}
 }
 
+// Wait waits for the executed command to exit
+func (launcher *Launcher) Wait() (*os.ProcessState, error) {
+	if launcher.cmd == nil || launcher.cmd.Process == nil {
+		return nil, errors.New("process not running")
+	}
+
+	return launcher.cmd.Process.Wait()
+}
+
 func (launcher *Launcher) CheckPlatform() error {
 	if err := settings.EnsureJavaExecutableAvailability(); err != nil {
 		return errors.Wrap(err, "java executable wasn't found")

--- a/launcher/launcher.go
+++ b/launcher/launcher.go
@@ -2,6 +2,7 @@ package launcher
 
 import (
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -21,6 +22,7 @@ type Launcher interface {
 	UninstallByFilename(filename string, showGUI bool) error
 	UninstallByURL(url string, showGUI bool) error
 	SetLogFile(logFile string)
+	Wait() (*os.ProcessState, error)
 }
 
 type Options struct {


### PR DESCRIPTION
Some users of the public Launcher interface of the launcher package may
want to wait for the launched process to exit. Support this by adding a
Wait function to Launcher which waits on the process to terminate.