### PR TITLE
use j2se variable and collapse on split

### DIFF
--- a/launcher/jnlp/launcher.go
+++ b/launcher/jnlp/launcher.go
@@ -212,12 +212,16 @@ func (launcher *Launcher) getProperties() []Property {
 }
 
 func (launcher *Launcher) getJVMArgs() []string {
+	splitter := func(c rune) bool {
+		return c == ' '
+	}
+
 	var jvmArgs []string
 	relevantResources := launcher.getRelevantResources()
 	for _, resources := range relevantResources {
 		j2se := resources.getJ2SE()
-		if j2se != nil && j2se.JavaVMArgs != "" {
-			args := strings.Split(resources.J2SE.JavaVMArgs, " ")
+		if j2se != nil && strings.Trim(j2se.JavaVMArgs, " ") != "" {
+			args := strings.FieldsFunc(j2se.JavaVMArgs, splitter)
 			jvmArgs = append(jvmArgs, args...)
 		}
 	}


### PR DESCRIPTION
The getJVMArgs() function has two problems:
 - It uses the J2SE pointer directly, rather than its abstraction,
   leading to null pointer accesses.
 - It splits on " " without collapsing consecutive occurances of the
   token, leading to invalid arguments being passed to the JVM (e.g. the
   main class is passed in as an empty string) when the xml has
   whitespace in the java-vm-args attribute.

Fix these two problems by using the proper variable for accessing the
JavaVMArgs, and split them in a fashion that skips consecutive
whitespace.

In a similar vein, also strip whitespace in the args prior to doing this
work so that an entirely empty attribute does not lead to us
unnecessarily adding arguments.