### PR TITLE
provide mechanisms to forward output from jnlp app

### DIFF
--- a/launcher/jnlp/launcher.go
+++ b/launcher/jnlp/launcher.go
@@ -299,6 +299,22 @@ func (launcher *Launcher) exec() error {
 	if launcher.gui.Closed() {
 		return errCancelled
 	}
+
+	if launcher.options != nil && launcher.options.StdoutHandler != nil {
+		pipe, err := cmd.StdoutPipe()
+		if err != nil {
+			return errors.Wrap(err, "failed to create stdout pipe to application")
+		}
+		go launcher.options.StdoutHandler(pipe)
+	}
+
+	if launcher.options != nil && launcher.options.StderrHandler != nil {
+		pipe, err := cmd.StderrPipe()
+		if err != nil {
+			return errors.Wrap(err, "failed to create stderr pipe to application")
+		}
+		go launcher.options.StderrHandler(pipe)
+	}
 	return cmd.Start()
 }
 

--- a/launcher/launcher.go
+++ b/launcher/launcher.go
@@ -1,6 +1,7 @@
 package launcher
 
 import (
+	"io"
 	"net/url"
 	"strings"
 
@@ -23,12 +24,22 @@ type Launcher interface {
 	SetLogFile(logFile string)
 }
 
+// OutputHandler is invoked with the read end of a pipe to which the Launcher forwards
+// output (stdout or stderr). Each instance of an OutputHandler will be provided its own
+// goroutine, so it may block as necessary.
+type OutputHandler = func(pipe io.ReadCloser)
+
 type Options struct {
 	IsRunningFromBrowser          bool
 	JavaDir                       string
 	ShowConsole                   bool
 	DisableVerification           bool
 	DisableVerificationSameOrigin bool
+
+	// If non-nil, processes output from stdout of the launched process
+	StdoutHandler OutputHandler
+	// If non-nil, processes output from stderr of the launched process
+	StderrHandler OutputHandler
 }
 
 func RegisterProtocol(scheme string, launcher Launcher) {


### PR DESCRIPTION
A misbehaving application may log information to stderr, or even stdout.
Sometimes it is useful to collect this information for diagnostic
purposes. Provide a mechanism to capture this output in a customizable
fashion using callback functions invoked on a goroutine with the
stdin/stderr pipe returned from the exec.Cmd we launch.

An example of using this:

```go
// makeLauncher makes a launcher configured to forward the launched applications stdout to logrus's Info level, and stderr to logrus's Error level.
func makeLauncher() launcher.Launcher {
	options := &launcher.Options{
		StdoutHandler: pipeLogger(logrus.Info),
		StderrHandler: pipeLogger(logrus.Error),
	}
        jnlpLauncher := jnlp.NewLauncher()
        jnlpLauncher.SetOptions(options)
       return jnlpLauncher
}

func pipeLogger(outFunc func(args ...interface{})) func(io.ReadCloser) {
	return func(input io.ReadCloser) {
		defer input.Close()
		scanner := bufio.NewScanner(input)
		for scanner.Scan() {
			outFunc(scanner.Text())
		}
	}
}
```
