### PR TITLE
do not disable tls verification in init

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1,10 +1,12 @@
 package bootstrap
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -41,6 +43,8 @@ func Run(productName, productTitle, productVersion string) {
 			}
 		}
 	}
+
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	userConfigDir, err := os.UserConfigDir()
 
 	userConfigDir = filepath.Join(userConfigDir, "Rocket Software")

--- a/utils/download/download.go
+++ b/utils/download/download.go
@@ -2,7 +2,6 @@ package download
 
 import (
 	"bytes"
-	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -99,8 +98,4 @@ func GetLastModifiedTime(url string) (time.Time, error) {
 		return time.Time{}, err
 	}
 	return lastModifiedTime, nil
-}
-
-func init() {
-	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 }


### PR DESCRIPTION
TLS verification for some reason is disabled by default globally by the
download package. This is done at init, which means simply importing the
package has the very dangerous, unexpected side effect of removing TLS
verification for any http client elsewere in the codebase using the
default http client.

Rather than disable TLS verification globally at init time, instead do
it as part of the bootstrap/run process so that applications using this
module do not inadvertently decrease their security.