### PR TITLE
support multiple java resources

### DIFF
--- a/launcher/jnlp/jnlp.go
+++ b/launcher/jnlp/jnlp.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 
 	launcher_utils "github.com/rocketsoftware/open-web-launch/launcher/utils"
+	"github.com/rocketsoftware/open-web-launch/settings"
 	"github.com/rocketsoftware/open-web-launch/utils/log"
 )
 
@@ -30,8 +31,8 @@ type Resources struct {
 	JARs       []*JAR       `xml:"jar,omitempty"`
 	Properties []Property   `xml:"property,omitempty"`
 	Extensions []*Extension `xml:"extension,omitempty"`
-	J2SE       *J2SE        `xml:"j2se,omitempty"`
-	Java       *J2SE        `xml:"java,omitempty"` // synonym for j2se
+	J2SE       []J2SE       `xml:"j2se,omitempty"`
+	Java       []J2SE       `xml:"java,omitempty"` // synonym for j2se
 	NativeLibs []*NativeLib `xml:"nativelib,omitempty"`
 }
 
@@ -236,11 +237,27 @@ func (jnlp *JNLP) Title() string {
 }
 
 func (resources *Resources) getJ2SE() *J2SE {
-	if resources.J2SE != nil {
-		return resources.J2SE
+	for _, j2seIter := range resources.J2SE {
+		j2se := &j2seIter
+		if j2se.versionMatches() {
+			return j2se
+		}
 	}
-	if resources.Java != nil {
-		return resources.Java
+	for _, j2seIter := range resources.Java {
+		j2se := &j2seIter
+		if j2se.versionMatches() {
+			return j2se
+		}
 	}
+
 	return nil
+}
+
+func (j2se *J2SE) versionMatches() bool {
+	requiredVersion, err := settings.ParseJavaVersion(j2se.Version)
+	if err != nil {
+		return false
+	}
+
+	return settings.CurrentJavaVersionMatches(requiredVersion)
 }


### PR DESCRIPTION
The jnlp specification
(https://docs.oracle.com/javase/7/docs/technotes/guides/javaws/developersguide/syntax.html)
allows for multiple `java`/`j2se` in one resource. The existing model of
the Resource struct allowed for zero or one, not zero to *. This leads
to some odd behaviour when encountering multiple j2se properties. In
particular, it seemed to merge the fields together, with the last
winning. The net result (in the case I ran into) was that java VM
arguments only available in 1.9+ were applied to a 1.8 VM, which lead to
it failing to start.

This changes the Resource model to accept an arbitrary number of
J2SE/Java properties. Further, it maintains the existing J2SE() semantic
of returning exactly one for a given resource by choosing the first
property which matches the java version, in line with the jnlp spec
which indicates a first-match semantic.