### PR TITLE
pass http proxy on java command line

### DIFF
--- a/settings/settings.go
+++ b/settings/settings.go
@@ -244,6 +244,11 @@ func UseHttpProxyEnvironmentVariable() bool {
 	return useHttpProxyEnvironmentVariable
 }
 
+// SetUseHttpProxyEnvironmentVariable allows overriding the default determined by the OS
+func SetUseHttpProxyEnvironmentVariable(use bool) {
+	useHttpProxyEnvironmentVariable = use
+}
+
 func init() {
 	javaExecutable = getJavaExecutable()
 	jarSignerExecutable = getJARSignerExecutable()


### PR DESCRIPTION
Often if we need a proxy to access the resources required by the java
app, the java app itself may need a proxy to access anything it
interacts with (e.g. APIs). Sometimes the env vars such as HTTP_PROXY
are insufficient to enable the proxy. Instead, it must be passed in on
the java command line. Hook this up.

At the same time, allow the launching application to force the proxies
to be used, even if the system would otherwise indicate not to. This
allows the launching application to use a different default proxy than
the system's configuration would.